### PR TITLE
Add include(CheckLibraryExists)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ if(SAMPLERATE_FOUND)
     include_directories(${SAMPLERATE_INCLUDE_DIR})
     add_definitions(${SAMPLERATE_DEFINITIONS})
 endif()
+
+include(CheckLibraryExists)
 check_library_exists(m log "" HAVE_LIBM)
 
 set(WINDOWS_RC_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
     # If this is gcc, we have some options we'd like to turn on.  Turn on 
     # optimisation and debugging symbols.
     add_compile_options(-Wall -Wredundant-decls)
+    add_compile_options(-std=c++14)
 endif()
 
 find_package(SDL2 2.0.1)

--- a/src/c_commands.h
+++ b/src/c_commands.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace console
 {

--- a/src/c_console.cpp
+++ b/src/c_console.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <array>
+#include <stdlib.h> // malloc,free
 
 #include "c_console.h"
 

--- a/src/doom/p_setup.cpp
+++ b/src/doom/p_setup.cpp
@@ -677,7 +677,7 @@ static void PadRejectArray(byte *array, unsigned int len)
 
     unsigned int rejectpad[4] =
     {
-        ((totallines * 4 + 3) & ~3) + 24,     // Size
+        (unsigned int)((totallines * 4 + 3) & ~3) + 24,     // Size
         0,                                    // Part of z_zone block header
         50,                                   // PU_LEVEL
         0x1d4a11                              // DOOM_CONST_ZONEID


### PR DESCRIPTION
Fixes cmake on OS X (cmake version 3.7.2)